### PR TITLE
Issue #5: Make new document save panel add '.shape' extension to file name if not present

### DIFF
--- a/Viewer/Utilities.swift
+++ b/Viewer/Utilities.swift
@@ -60,6 +60,7 @@ func showNewDocumentPanel() {
     let dialog = NSSavePanel()
     dialog.title = "New Document"
     dialog.showsHiddenFiles = true
+    dialog.allowedFileTypes = ["shape"]
     dialog.nameFieldStringValue = "Untitled.shape"
     dialog.begin { response in
         guard response == .OK, let url = dialog.url else {


### PR DESCRIPTION
Should fix #5﻿.

This assumes that you'd never want to allow the user to create a file without the .shape extension.
