### PR TITLE
Add modulo operator

### DIFF
--- a/ShapeScript/Interpreter.swift
+++ b/ShapeScript/Interpreter.swift
@@ -1277,6 +1277,8 @@ extension Expression {
                 return .number(lhs.doubleValue * rhs.doubleValue)
             case .divide:
                 return .number(lhs.doubleValue / rhs.doubleValue)
+            case .modulo:
+                return .number(lhs.doubleValue % rhs.doubleValue)
             case .lt:
                 return .boolean(lhs.doubleValue < rhs.doubleValue)
             case .gt:

--- a/ShapeScript/Lexer.swift
+++ b/ShapeScript/Lexer.swift
@@ -59,6 +59,7 @@ public enum InfixOperator: String, CaseIterable {
     case minus = "-"
     case times = "*"
     case divide = "/"
+    case modulo = "%"
     // Comparison operators
     case lt = "<"
     case gt = ">"

--- a/ShapeScript/Types.swift
+++ b/ShapeScript/Types.swift
@@ -613,6 +613,7 @@ extension Expression {
              let .infix(lhs, .plus, rhs),
              let .infix(lhs, .times, rhs),
              let .infix(lhs, .divide, rhs),
+             let .infix(lhs, .modulo, rhs),
              let .infix(lhs, .lt, rhs),
              let .infix(lhs, .gt, rhs),
              let .infix(lhs, .lte, rhs),
@@ -711,6 +712,7 @@ extension Expression {
              .infix(_, .plus, _),
              .infix(_, .times, _),
              .infix(_, .divide, _):
+             .infix(_, .modulo, _):
             return .number
         case .infix(_, .to, _), .infix(_, .step, _):
             return .range

--- a/docs/ios/expressions.md
+++ b/docs/ios/expressions.md
@@ -22,6 +22,7 @@ Symbol         | Name                  | Function
 &dash;         | minus                 | Subtracts the right value from the left value
 &ast;          | times                 | Multiplies the left value by the right value
 &sol;          | divide                | Divides the left value by the right value
+&percnt;       | modulo                | Remainder of dividing the left value by the right value
 
 <br>
 

--- a/docs/mac/expressions.md
+++ b/docs/mac/expressions.md
@@ -22,6 +22,7 @@ Symbol         | Name                  | Function
 &dash;         | minus                 | Subtracts the right value from the left value
 &ast;          | times                 | Multiplies the left value by the right value
 &sol;          | divide                | Divides the left value by the right value
+&percnt;       | modulo                | Remainder of dividing the left value by the right value
 
 <br>
 

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -22,6 +22,7 @@ Symbol         | Name                  | Function
 &dash;         | minus                 | Subtracts the right value from the left value
 &ast;          | times                 | Multiplies the left value by the right value
 &sol;          | divide                | Divides the left value by the right value
+&percnt;       | modulo                | Remainder of dividing the left value by the right value
 
 <br>
 


### PR DESCRIPTION
This adds the modulo operator `%`.

I couldn't find any examples of tests for the other arithmetic operators to use as a base and this is my first time touching Swift code, so I wasn't sure the best way to write them. I'd like to write some if you can point me at the right place.